### PR TITLE
Debug: Fix formatting of Spots responses

### DIFF
--- a/backend/routes/api/spots.js
+++ b/backend/routes/api/spots.js
@@ -113,6 +113,10 @@ function formatSpots(spots) {
   spots = {Spots: JSON.parse(JSON.stringify(spots))};
 
   spots.Spots.forEach(spot => {
+    spot.lat = Number(spot.lat);
+    spot.lng = Number(spot.lng);
+    spot.price = Number(spot.price);
+
     const totalStars = spot.Reviews.reduce((sum, review) => {
       return sum + review.stars;
     }, 0);


### PR DESCRIPTION
Some attributes of Spots returned in responses were strings, but were fixed to output as numbers.