### PR TITLE
Debug: Fix formatting of Spots responses

### DIFF
--- a/backend/routes/api/spots.js
+++ b/backend/routes/api/spots.js
@@ -38,6 +38,9 @@ router.get('/:spotId', async (req, res) => {
   }
 
   spot = spot.toJSON();
+  spot.lat = Number(spot.lat);
+  spot.lng = Number(spot.lng);
+  spot.price = Number(spot.price);
   spot.numReviews = spot.Reviews.length;
   const totalStars = spot.Reviews.reduce((sum, review) => sum + review.stars, 0);
   spot.avgStarRating = totalStars / spot.numReviews;


### PR DESCRIPTION
Fix formatting where 'Get details of a Spot from an id' response attributes were still outputting as strings instead of numbers